### PR TITLE
Remove unused env vars, fix typos & set minio host with variable

### DIFF
--- a/Submission-Keycloack/.env
+++ b/Submission-Keycloack/.env
@@ -1,17 +1,13 @@
-
 dareVer=2.7.0
 
 
 PGLOGIN=admin
 PGPASSWORD=admin
 
-#KeyCloakURL=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration
-
-
 no_proxy=192.168.*.*,172.17.*.*,localhost,0.0.0.0,127.0.0.1,minioAAA
 http_proxy=http://192.168.10.15:8080
 https_proxy=http://192.168.10.15:8080
-ProxyAddresURLForExternalFetch=http://192.168.10.15:8080
+ProxyAddressURLForExternalFetch=http://192.168.10.15:8080
 
 useproxy=false
 proxyurl=http://192.168.10.15:8080
@@ -24,98 +20,31 @@ MinioOpenidSecret=8a11bbcd-693a-4549-bda4-3e978fcf4de1
 MinioIdentityID=Dare-Control-Minio
 MinioIdentityConfigURL=http://keycloak:8080//realms/Dare-Control/.well-known/openid-configuration
 MinioTreOpenidSecret=71ee3de3-0e0c-49c8-a0b2-c0e490c90591
-MinioTreIdentityID=Dare-TRE-Minio
-MinioTreIdentityConfigURL=http://keycloak:8080//realms/Dare-Tre/.well-known/openid-configuration
 
 MinioRootUser=minio
 MinioRootPass=minio123
-MinioBrowser=http://localhost:9000
-#MinioServerApi=http://127.0.0.1:9000
- 
-UseTESK=false
-UseHutch=true
-UseRabbit=false
-
-IgnoreHutchSSL=true
-HutchAPIAddress=https://localhost:7239
-HutchDbServer=theserver
-HutchDbName=theDb
-HutchDbPort=24
-
-syncSchedule=10
-scanSchedule=1
-TreName=DEMO
-EnableExternalHangfire=false
-
-HutchMinioURLOverride=
-TreMinioAdminUser=minio
-TreMinioAdminPassword=minio123
 
 submissionMinioUrl=http://minioAAA:9000
 #This is the 9001 url
 submissionMinioAdminConsole=http://minioAAA:9001
 
-
-EgressKeyCloakUseRedirect=false
-EgressKeyCloakBaseRealmAddress=http://keycloak:8080/realms/Data-Egress
-EgressKeyCloakAuthority=http://keycloak:8080/realms/Data-Egress/.well-known/openid-configuration
-EgressKeyCloakMetadataAddress=http://keycloak:8080/realms/Data-Egress/.well-known/openid-configuration
-EgressValidAudiences=Data-Egress-UI,Data-Egress-API
-EgressKeyCloakClientUIRediretURL=https//localhost:8100/
-EgressKeyCloakTokenExpredAddressUI=http://localhost:8100/Account/LoginAfterTokenExpired
-EgressKeyCloakSecret=81c1f071-8c45-49ef-a966-84ca8f420b7e
-EgressKeyCloakClientID=Data-Egress-API
-
-
-SubmissionAPIKeyCloakUseRedirect=false
-SubmissionAPIKeyCloakClientId=Dare-Control-API
 SubmissionAPIKeyCloakBaseRealmAddress=http://keycloak:8080/realms/Dare-Control
 SubmissionAPIKeyCloakAuthority=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration
 SubmissionAPIKeyCloakMetadataAddress=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration
-SubmissionAPIValidAudiences=Dare-Control-UI,Dare-Control-API,Dare-Control-Minio
-SubmissionAPIKeyCloakClientUIRedirectURL=http://localhost:8989/
-SubmissionAPIKeyCloakTokenExpredAddressUI=http://localhost:8989/Account/LoginAfterTokenExpired
 SubmissionAPIKeyCloakSecret=2e60b956-16bc-4dea-8b49-118a8baac5e5
-
-
 
 SubmissionUIAccountManagementURL=http://keycloak:8080/realms/Dare-Control/account
 SubmissionUIKeyCloakBaseUrl=http://keycloak:8080/realms/Dare-Control
 KeyCloakUseRedirect=false
-KeyCloakClientUIRediretURL=http://localhost:8888/
-KeyCloakTokenExpredAddressUI=http://localhost:8888/Account/LoginAfterTokenExpired
+KeyCloakClientUIRedirectURL=http://localhost:8888/
+KeyCloakTokenExpiredAddressUI=http://localhost:8888/Account/LoginAfterTokenExpired
 SubmissionUIClientSecret=1218304e-bf92-4706-83f6-912e0b04ecb9
 SubmissionUIKeyCloakMetadataAddress=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration
 SubmissionUIKeyCloakAuthority=http://keycloak:8080/realms/Dare-Control/
 
-TreKeyCloakUseRedirect=false
-TreKeyCloakClientUIRediretURL=http://localhost:8989/
-TreKeyCloakTokenExpredAddressUI=http://localhost:8989/Account/LoginAfterTokenExpired
-TreKeyCloakSecret=2de114bc-3599-45f1-9b61-5090c6859dfe
-TreKeyCloakBaseRealmAddress=http://keycloak:8080/realms/Dare-TRE
-TreKeyCloakAuthority=http://keycloak:8080/realms/Dare-TRE/.well-known/openid-configuration
-TreKeyCloakClientId=Dare-TRE-UI
-TreKeyCloakMetadataAddress=http://keycloak:8080/realms/Dare-TRE/.well-known/openid-configuration
-TreAccountManagementURLUI=http://localhost:8085/realms/Dare-TRE/account
-TreValidAudiences=Dare-TRE-API,Dare-TRE-UI
-
-TreAPIKeyCloakUseRedirect=false
-TreAPIKeyCloakClientUIRediretURL=http://localhost:8989/
-TreAPIKeyCloakTokenExpredAddressUI=http://localhost:8989/Account/LoginAfterTokenExpired
-TreAPIKeyCloakSecret=e9021a57-3f4f-4254-ba27-2cdbb99a2cb5
-TreAPIKeyCloakBaseRealmAddress=http://keycloak:8080/realms/Dare-TRE
-TreAPIKeyCloakAuthority=http://keycloak:8080/realms/Dare-TRE/.well-known/openid-configuration
-TreAPIKeyCloakClientId=Dare-TRE-API
-TreAPIKeyCloakMetadataAddress=http://keycloak:8080/realms/Dare-TRE/.well-known/openid-configuration
-TreAPIAccountManagementURLUI=http://localhost:8085/realms/Dare-TRE/account
-TreAPIValidAudiences=Dare-TRE-API,Dare-TRE-UI
-
-
 URLSettingsFrontEndQueryImage=harbor.ukserp.ac.uk/dare-trefx/control-tre-hasura:1.34.1
 URLSettingsFrontEndMinioUrl=s3.trefx.ukserp.ac.uk
 
-#SubmissionAPIKeyCloakUseRedirect=false
-#SubmissionAPIClientSecret=1218304e-bf92-4706-83f6-912e0b04ecb9
 SuppressAntiforgery=false
 SubmissionSignedOutRedirectUri=/
 SubmissionTokenRefreshSeconds=3600

--- a/Submission-Keycloack/.env
+++ b/Submission-Keycloack/.env
@@ -16,6 +16,8 @@ sslcookies=false
 #If http only site set this to false
 httpsRedirect=false
 
+keycloakHostName=http://localhost:8085
+
 MinioOpenidSecret=8a11bbcd-693a-4549-bda4-3e978fcf4de1
 MinioIdentityID=Dare-Control-Minio
 MinioIdentityConfigURL=http://keycloak:8080//realms/Dare-Control/.well-known/openid-configuration

--- a/Submission-Keycloack/docker-compose.yml
+++ b/Submission-Keycloack/docker-compose.yml
@@ -298,7 +298,7 @@ volumes:
     driver: local
   postgresql_kc:
     driver: local
-    minio_data:
+  minio_data:
     driver: local
   seq_data:
     driver: local

--- a/Submission-Keycloack/docker-compose.yml
+++ b/Submission-Keycloack/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.7'
+version: "3.7"
 
 services:
-
-######################################################
-# TRE Proxy
-######################################################
+  ######################################################
+  # TRE Proxy
+  ######################################################
 
   nginx-dare:
     image: nginx:latest
@@ -19,11 +18,9 @@ services:
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf
 
-
-
-######################################################
-# SUBMISSION LAYER
-######################################################
+  ######################################################
+  # SUBMISSION LAYER
+  ######################################################
 
   submissionUI:
     platform: linux/x86_64
@@ -36,7 +33,7 @@ services:
       - 7220:80
       - 8888:80
     depends_on:
-      - submissionAPI      
+      - submissionAPI
     volumes:
       - data-protection:/root/.aspnet/DataProtection-Keys
     environment:
@@ -51,24 +48,24 @@ services:
       - SubmissionKeyCloakSettings__Proxy=${useproxy}
       - SubmissionKeyCloakSettings__ProxyAddresURL=${proxyurl}
       - SubmissionKeyCloakSettings__BypassProxy="submissionAPI,seq"
-      - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpredAddressUI}
+      - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpiredAddressUI}
       - SubmissionKeyCloakSettings__UseRedirectURL=${KeyCloakUseRedirect}
-      - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRediretURL}
+      - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRedirectURL}
       - SubmissionKeyCloakSettings__ClientSecret=${SubmissionUIClientSecret}
       - SubmissionKeyCloakSettings__AccountManagementURL=${SubmissionUIAccountManagementURL}
       - SubmissionKeyCloakSettings__BaseUrl=${SubmissionUIKeyCloakBaseUrl}
-      - SuppressAntiforgery=${SuppressAntiforgery} 
+      - SuppressAntiforgery=${SuppressAntiforgery}
       - SubmissionKeyCloakSettings__MetadataAddress=${SubmissionUIKeyCloakMetadataAddress}
       - SubmissionKeyCloakSettings__Authority=${SubmissionUIKeyCloakAuthority}
       - URLSettingsFrontEnd__QueryImage=${URLSettingsFrontEndQueryImage}
       - URLSettingsFrontEnd__MinioUrl=${URLSettingsFrontEndMinioUrl}
       - sslcookies=${sslcookies}
       - httpsRedirect=${httpsRedirect}
-      
-# AccountManagementURL BaseUrl MetadataAddress Authority
-      
-#      - URLSettingsFrontEnd__MinioUrl=192.168.70.87:9001
-  
+
+  # AccountManagementURL BaseUrl MetadataAddress Authority
+
+  #      - URLSettingsFrontEnd__MinioUrl=192.168.70.87:9001
+
   submissionAPI:
     platform: linux/x86_64
     image: harbor.ukserp.ac.uk:443/dare-trefx/control-main-api:${dareVer}
@@ -82,12 +79,12 @@ services:
     volumes:
       - data-protection:/root/.aspnet/DataProtection-Keys
     depends_on:
-      keycloak: 
+      keycloak:
         condition: service_healthy
       postgresql:
         condition: service_healthy
       rabbitmq:
-        condition: service_healthy  
+        condition: service_healthy
       minioAAA:
         condition: service_healthy
     environment:
@@ -96,19 +93,19 @@ services:
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Control;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
-      #- MinioSettings__ProxyAddresURLForExternalFetch=${ProxyAddresURLForExternalFetch}
-      - MinioSettings__Url=http://minioAAA:9000
+      #- MinioSettings__ProxyAddressURLForExternalFetch=${ProxyAddressURLForExternalFetch}
+      - MinioSettings__Url=${submissionMinioUrl}
       - MinioSettings__AccessKey=${MinioRootUser}
       - MinioSettings__SecretKey=${MinioRootPass}
       - MinioSettings__BucketName=testbucket
       - SuppressAntiforgery=${SuppressAntiforgery}
-      - MinioSettings__AdminConsole=http://minioAAA:9001
+      - MinioSettings__AdminConsole=${submissionMinioAdminConsole}
       - SubmissionKeyCloakSettings__Proxy=${useproxy}
       - SubmissionKeyCloakSettings__ProxyAddresURL=${proxyurl}
       - SubmissionKeyCloakSettings__BypassProxy=minioAAA,seq
       - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpredAddressUI}
       - SubmissionKeyCloakSettings__UseRedirectURL=${KeyCloakUseRedirect}
-      - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRediretURL}
+      - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRedirectURL}
       - SubmissionKeyCloakSettings__BaseUrl=${SubmissionAPIKeyCloakBaseRealmAddress}
       - SubmissionKeyCloakSettings__MetadataAddress=${SubmissionAPIKeyCloakMetadataAddress}
       - SubmissionKeyCloakSettings__Authority=${SubmissionAPIKeyCloakAuthority}
@@ -124,15 +121,13 @@ services:
       - SubmissionKeyCloakSettings__ValidIssuer=${SubmissionValidIssuer}
       - SubmissionKeyCloakSettings__ValidAudience=${SubmissionValidAudience}
 
-      
-######################################################
-# Keycloak
-######################################################
+  ######################################################
+  # Keycloak
+  ######################################################
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
     container_name: keycloak
     environment:
-      
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres/keycloak
       KC_DB_USERNAME: ${PGLOGIN}
@@ -151,11 +146,10 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       # Admin credentials
-  
-      
+
       # Enable client and user configuration during startup
     networks:
-      - sub-net 
+      - sub-net
     command: start-dev  --import-realm #--verbose
     depends_on:
       postgresql:
@@ -165,24 +159,27 @@ services:
     volumes:
       - ./realm-config:/opt/keycloak/data/import
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/0.0.0.0/9000; echo -e \"GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q '\"status\": \"UP\"' <&3; exec 3<&- 3>&-"]
+      test:
+        [
+          "CMD-SHELL",
+          "exec 3<>/dev/tcp/0.0.0.0/9000; echo -e \"GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q '\"status\": \"UP\"' <&3; exec 3<&- 3>&-",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 45s
       start_interval: 5s
 
-
-######################################################
-# POSTGRES
-######################################################
+  ######################################################
+  # POSTGRES
+  ######################################################
   postgresql:
     platform: linux/x86_64
     image: docker.io/bitnami/postgresql:latest
     container_name: postgres
     restart: always
     environment:
-#      - ALLOW_EMPTY_PASSWORD=yes
+      #      - ALLOW_EMPTY_PASSWORD=yes
       - POSTGRESQL_USERNAME=${PGLOGIN}
       - POSTGRESQL_DATABASE=DARE-Control
       - POSTGRESQL_PASSWORD=${PGPASSWORD}
@@ -191,10 +188,10 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - 'postgresql_data:/bitnami/postgresql'
+      - "postgresql_data:/bitnami/postgresql"
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -q -U ${PGLOGIN} -d ${PGLOGIN}" ]
+      test: ["CMD-SHELL", "pg_isready -q -U ${PGLOGIN} -d ${PGLOGIN}"]
 
   adminer:
     image: adminer
@@ -211,25 +208,25 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "nc", "-z", "adminer", "9000" ]
+      test: ["CMD", "nc", "-z", "adminer", "9000"]
       timeout: 45s
       interval: 10s
       retries: 10
 
-######################################################
-# Rabbit MQ
-######################################################
+  ######################################################
+  # Rabbit MQ
+  ######################################################
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
-    container_name: 'rabbitmq'
+    container_name: "rabbitmq"
     hostname: rabbitmq
     ports:
-        - 5672:5672
-        - 15672:15672
+      - 5672:5672
+      - 15672:15672
     volumes:
-        - rabbitdata:/var/lib/rabbitmq/
-        - rabbitlogs:/var/log/rabbitmq
+      - rabbitdata:/var/lib/rabbitmq/
+      - rabbitlogs:/var/log/rabbitmq
     networks:
       - sub-net
     healthcheck:
@@ -238,17 +235,16 @@ services:
       timeout: 30s
       retries: 3
 
-
-######################################################
-# MINIO
-######################################################
+  ######################################################
+  # MINIO
+  ######################################################
   minioAAA:
     image: quay.io/minio/minio
     container_name: minioAAA
     restart: always
     command: server /data --console-address ":9001"
     depends_on:
-      keycloak: 
+      keycloak:
         condition: service_healthy
     environment:
       - MINIO_ROOT_USER=${MinioRootUser}
@@ -277,9 +273,9 @@ services:
       timeout: 10s
       retries: 5
       start_period: 5s
-######################################################
-# SEQ / Serilog
-######################################################
+  ######################################################
+  # SEQ / Serilog
+  ######################################################
   seq:
     platform: linux/x86_64
     image: datalust/seq:latest
@@ -298,25 +294,22 @@ services:
 # VOLUME
 ######################################################
 volumes:
-    postgresql_data:
-      driver: local
-    postgresql_kc:
-      driver: local
+  postgresql_data:
+    driver: local
+  postgresql_kc:
+    driver: local
     minio_data:
-      driver: local
-    minio2_data:
-      driver: local
-    seq_data:
-      driver: local
-    rabbitdata:
-      driver: local
-    rabbitlogs:
-      driver: local
-    keycloak_data:
-      driver: local  
-    data-protection:
-      driver: local 
-       
+    driver: local
+  seq_data:
+    driver: local
+  rabbitdata:
+    driver: local
+  rabbitlogs:
+    driver: local
+  keycloak_data:
+    driver: local
+  data-protection:
+    driver: local
 
 ######################################################
 # networks

--- a/Submission-Keycloack/docker-compose.yml
+++ b/Submission-Keycloack/docker-compose.yml
@@ -132,12 +132,12 @@ services:
       KC_DB_URL: jdbc:postgresql://postgres/keycloak
       KC_DB_USERNAME: ${PGLOGIN}
       KC_DB_PASSWORD: ${PGPASSWORD}
-      KC_HOSTNAME: http://localhost:8085
+      KC_HOSTNAME: ${keycloakHostName}
       KC_HOSTNAME_PORT: 8085
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
       #KC_HOSTNAME_STRICT: false
       #KC_HOSTNAME_STRICT_HTTPS: false
-      KEYCLOAK_FRONTEND_URL: http://localhost:8085/auth
+      KEYCLOAK_FRONTEND_URL: ${keycloakHostName}/auth
       KC_LOG_LEVEL: info
       KC_METRICS_ENABLED: true
       KC_HEALTH_ENABLED: true


### PR DESCRIPTION
- Remove env vars that are not used in the Submission docker-compose
- Fix typos and match in both files
- Set minio host with the existing env vars instead of directly in the file
- Set Keycloak hostname in env vars