### PR TITLE
Fix typo in config var

### DIFF
--- a/Submission-Keycloack/.env
+++ b/Submission-Keycloack/.env
@@ -25,6 +25,7 @@ MinioTreOpenidSecret=71ee3de3-0e0c-49c8-a0b2-c0e490c90591
 
 MinioRootUser=minio
 MinioRootPass=minio123
+MinioBrowserHost=localhost
 
 submissionMinioUrl=http://minioAAA:9000
 #This is the 9001 url

--- a/Submission-Keycloack/.env
+++ b/Submission-Keycloack/.env
@@ -4,7 +4,7 @@ dareVer=2.7.0
 PGLOGIN=admin
 PGPASSWORD=admin
 
-no_proxy=192.168.*.*,172.17.*.*,localhost,0.0.0.0,127.0.0.1,minioAAA
+no_proxy=192.168.*.*,172.17.*.*,localhost,0.0.0.0,127.0.0.1,minio
 http_proxy=http://192.168.10.15:8080
 https_proxy=http://192.168.10.15:8080
 ProxyAddressURLForExternalFetch=http://192.168.10.15:8080
@@ -27,9 +27,9 @@ MinioRootUser=minio
 MinioRootPass=minio123
 MinioBrowserHost=localhost
 
-submissionMinioUrl=http://minioAAA:9000
+submissionMinioUrl=http://minio:9000
 #This is the 9001 url
-submissionMinioAdminConsole=http://minioAAA:9001
+submissionMinioAdminConsole=http://minio:9001
 
 SubmissionAPIKeyCloakBaseRealmAddress=http://keycloak:8080/realms/Dare-Control
 SubmissionAPIKeyCloakAuthority=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration

--- a/Submission-Keycloack/docker-compose.yml
+++ b/Submission-Keycloack/docker-compose.yml
@@ -85,7 +85,7 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
-      minioAAA:
+      minio:
         condition: service_healthy
     environment:
       - DemoMode=false
@@ -102,7 +102,7 @@ services:
       - MinioSettings__AdminConsole=${submissionMinioAdminConsole}
       - SubmissionKeyCloakSettings__Proxy=${useproxy}
       - SubmissionKeyCloakSettings__ProxyAddresURL=${proxyurl}
-      - SubmissionKeyCloakSettings__BypassProxy=minioAAA,seq
+      - SubmissionKeyCloakSettings__BypassProxy=minio,seq
       - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpredAddressUI}
       - SubmissionKeyCloakSettings__UseRedirectURL=${KeyCloakUseRedirect}
       - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRedirectURL}
@@ -137,7 +137,7 @@ services:
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
       #KC_HOSTNAME_STRICT: false
       #KC_HOSTNAME_STRICT_HTTPS: false
-      KEYCLOAK_FRONTEND_URL: ${keycloakHostName}/auth
+      KEYCLOAK_FRONTEND_URL: ${KeycloakHostName}/auth
       KC_LOG_LEVEL: info
       KC_METRICS_ENABLED: true
       KC_HEALTH_ENABLED: true
@@ -238,9 +238,9 @@ services:
   ######################################################
   # MINIO
   ######################################################
-  minioAAA:
+  minio:
     image: quay.io/minio/minio
-    container_name: minioAAA
+    container_name: minio
     restart: always
     command: server /data --console-address ":9001"
     depends_on:
@@ -249,8 +249,8 @@ services:
     environment:
       - MINIO_ROOT_USER=${MinioRootUser}
       - MINIO_ROOT_PASSWORD=${MinioRootPass}
-      - MINIO_BROWSER_REDIRECT_URL=http://localhost:9001
-      - MINIO_SERVER_URL=http://localhost:9000
+      - MINIO_BROWSER_REDIRECT_URL=http://${MinioBrowserHost}:9001
+      - MINIO_SERVER_URL=http://${MinioBrowserHost}:9000
       - MINIO_IDENTITY_OPENID_CONFIG_URL=${MinioIdentityConfigURL}
       - MINIO_IDENTITY_OPENID_CLIENT_ID=${MinioIdentityID}
       - MINIO_IDENTITY_OPENID_CLIENT_SECRET=${MinioOpenidSecret}

--- a/Submission-Keycloack/docker-compose.yml
+++ b/Submission-Keycloack/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - SubmissionKeyCloakSettings__Proxy=${useproxy}
       - SubmissionKeyCloakSettings__ProxyAddresURL=${proxyurl}
       - SubmissionKeyCloakSettings__BypassProxy=minio,seq
-      - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpredAddressUI}
+      - SubmissionKeyCloakSettings__TokenExpiredAddress=${KeyCloakTokenExpiredAddressUI}
       - SubmissionKeyCloakSettings__UseRedirectURL=${KeyCloakUseRedirect}
       - SubmissionKeyCloakSettings__RedirectURL=${KeyCloakClientUIRedirectURL}
       - SubmissionKeyCloakSettings__BaseUrl=${SubmissionAPIKeyCloakBaseRealmAddress}


### PR DESCRIPTION
- Fix typo in config var
- Match minio container name in docker-compose.yml & .env to `minio`