### PR TITLE
Fix minio keycloak url

### DIFF
--- a/TRE-Keycloak/.env
+++ b/TRE-Keycloak/.env
@@ -16,7 +16,7 @@ KeycloakHostName=http://localhost:8085
 
 MinioTreOpenidSecret=71ee3de3-0e0c-49c8-a0b2-c0e490c90591
 MinioTreIdentityID=Dare-TRE-Minio
-MinioTreIdentityConfigURL=http://keycloak:8080/realms/Dare-Tre/.well-known/openid-configuration
+MinioTreIdentityConfigURL=http://keycloak:8080/realms/Dare-TRE/.well-known/openid-configuration
 
 MinioRootUser=minio
 MinioRootPass=minio123
@@ -48,9 +48,10 @@ HutchMinioURLOverride=
 TreMinioAdminUser=minio
 TreMinioAdminPassword=minio123
 
-submissionMinioUrl=http://minioAAA:9000
+# Point to submission minio
+submissionMinioUrl=http://minio:9000
 #This is the 9001 url
-submissionMinioAdminConsole=http://minioAAA:9001
+submissionMinioAdminConsole=http://minio:9001
 
 
 EgressKeyCloakUseRedirect=false

--- a/TRE-Keycloak/docker-compose.yml
+++ b/TRE-Keycloak/docker-compose.yml
@@ -392,7 +392,7 @@ services:
     networks:
       - sub-net
     volumes:
-      - minio:/data
+      - minio_data:/data
     ports:
       - 9002:9000
       - 9003:9001


### PR DESCRIPTION
MinIO keycloak OpenID was failing:
- Change name of realm from `Dare-Tre` to `Dare-TRE`
- Fix volume name from previous change