### PR TITLE
feat: add ansible playbook to install/setup funnel

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,10 @@
+# Ansible for Funnel Provisions
+
+```
+ansible-playbook provision-funnel.yml -i ./inventory/live
+```
+
+You'll be prompted for two inputs - these are the minio key and secret
+These are marked as secure, so you won't see an input in the terminal
+
+You will need to add target ips to ./inventory/live/hosts

--- a/ansible/inventory/live/hosts
+++ b/ansible/inventory/live/hosts
@@ -1,0 +1,2 @@
+[funnel]
+# 255.255.255.255 # put target ip here and uncomment

--- a/ansible/provision-funnel.yml
+++ b/ansible/provision-funnel.yml
@@ -1,0 +1,14 @@
+---
+
+- name: 'provision funnel'
+  hosts: 'funnel'
+  remote_user: 'root'
+  vars_prompt:
+    - name: minio_key
+      prompt: What is the minio key?
+      private: true
+    - name: minio_secret
+      prompt: What is the minio secret?
+      private: true
+  roles: 
+    - 'funnel'

--- a/ansible/roles/funnel/defaults/main.yml
+++ b/ansible/roles/funnel/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+funnel_version: "0.11.2"

--- a/ansible/roles/funnel/files/funnel.service
+++ b/ansible/roles/funnel/files/funnel.service
@@ -1,0 +1,15 @@
+[Unit]
+Descrption=Funnel Server
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/funnel server run -c /etc/funnel/funnelconfig.yml
+Restart=always
+WorkingDirectory=/var/lib/funnel
+StandardOutput=file:/var/log/funnel.log
+StandardError=file:/var/log/funnel.err
+User=funnel
+Group=funnel
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/funnel/tasks/main.yml
+++ b/ansible/roles/funnel/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+
+- name: 'download the {{ funnel_version }} funnel binary archive'
+  ansible.builtin.get_url:
+    url: "https://github.com/ohsu-comp-bio/funnel/releases/download/{{ funnel_version }}/funnel-linux-amd64-{{ funnel_version }}.tar.gz"
+    dest: '/tmp/funnel.tar.gz'
+    mode: 0644
+
+- name: 'extract the funnel binary'
+  ansible.builtin.unarchive:
+    src: '/tmp/funnel.tar.gz'
+    dest: '/usr/local/bin'
+
+- name: 'ensure funnel user exists'
+  ansible.builtin.user:
+    name: 'funnel'
+    system: true
+    shell: '/usr/sbin/nologin'
+    create_home: false
+
+- name: 'create funnel config directory'
+  ansible.builtin.file:
+    path: '/etc/funnel/'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: 0755
+
+- name: 'create funnel working directory'
+  ansible.builtin.file:
+    path: '/var/lib/funnel/'
+    state: 'directory'
+    owner: 'funnel'
+    group: 'funnel'
+    mode: 0755
+
+- name: 'create funnel log directory'
+  ansible.builtin.file:
+    path: '/var/log/funnel/'
+    state: 'directory'
+    owner: 'funnel'
+    group: 'funnel'
+    mode: 0755
+
+- name: 'create the funnel config'
+  ansible.builtin.template:
+    src: 'funnelconfig.yml.j2'
+    dest: '/etc/funnel/funnelconfig.yml'
+    owner: 'root'
+    group: 'root'
+    mode: 0644
+
+- name: 'create funnel systemd unit file'
+  ansible.builtin.copy:
+    src: 'funnel.service'
+    dest: '/etc/systemd/system/funnel.service'
+    owner: 'root'
+    group: 'root'
+    mode: 0644
+
+- name: 'reload systemd to pull in the new file'
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: 'enable start and enable funnel'
+  ansible.builtin.systemd:
+    name: 'funnel'
+    state: 'started'
+    enabled: true

--- a/ansible/roles/funnel/templates/funnelconfig.yml.j2
+++ b/ansible/roles/funnel/templates/funnelconfig.yml.j2
@@ -1,0 +1,7 @@
+---
+
+GenericS3:
+  - Disabled: false
+    Endpoint: "submissionminioip:9002"
+    Key: "{{ minio_key }}"
+    Secret: "{{ minio_secret }}"


### PR DESCRIPTION
few opinionated changes in here from what was done on the box manually
1) creates a funnel user and workspace to be used when the server is up
2) uses systemd unit to spin up funnel meaning it'll stay active regardless of the user session/persist through server reboots
3) downloads the binary directly instead of using the install script

Any of these I can easily rollback, just let me know.

Finally there's a readme which covers a few assumptions:
- we are able to ssh in as root to run this playbook
- the person running the play will be able to supply the minio key and secret at provision time