### PR TITLE
update All In One to run latest release: 2.9.0

### DIFF
--- a/AllInOne/.env
+++ b/AllInOne/.env
@@ -1,12 +1,14 @@
 
-dareVer=2.7.0
+dareVer=2.9.0
 
 
 PGLOGIN=admin
 PGPASSWORD=admin
 
-#KeyCloakURL=http://keycloak:8080/realms/Dare-Control/.well-known/openid-configuration
-
+# Set to true if you'd like to simulate execution, otherwise default to false:
+DemoMode = true
+# Allows Keycloak to not require https:
+KeyCloakDemoMode=true
 
 no_proxy=192.168.*.*,172.17.*.*,localhost,0.0.0.0,127.0.0.1,minioAAA
 http_proxy=http://192.168.10.15:8080
@@ -33,7 +35,6 @@ MinioBrowser=http://localhost:9000
 #MinioServerApi=http://127.0.0.1:9000
  
 UseTESK=false
-UseHutch=true
 UseRabbit=false
 
 IgnoreHutchSSL=true
@@ -112,7 +113,7 @@ TreAPIValidAudiences=Dare-TRE-API,Dare-TRE-UI
 
 
 URLSettingsFrontEndQueryImage=harbor.ukserp.ac.uk/dare-trefx/control-tre-hasura:1.34.1
-URLSettingsFrontEndMinioUrl=s3.trefx.ukserp.ac.uk
+URLSettingsFrontEndMinioUrl=localhost:9001
 
 #SubmissionAPIKeyCloakUseRedirect=false
 #SubmissionAPIClientSecret=1218304e-bf92-4706-83f6-912e0b04ecb9

--- a/AllInOne/.env
+++ b/AllInOne/.env
@@ -37,6 +37,11 @@ MinioBrowser=http://localhost:9000
 UseTESK=false
 UseRabbit=false
 
+# Where TESK or Funnel API is hosted:
+TesAPIUrl=http://host.docker.internal:8000/v1/tasks
+# Output bucket prefix for the TES executing agent to write results to
+TesOutputBucketPrefix=s3://
+
 IgnoreHutchSSL=true
 HutchAPIAddress=https://localhost:7239
 HutchDbServer=theserver

--- a/AllInOne/docker-compose.yml
+++ b/AllInOne/docker-compose.yml
@@ -41,8 +41,8 @@ services:
     environment:
       - TreAPISettings__Address=http://treAPI    
       - Serilog__SeqServerUrl=http://seq:5341
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - DemoMode=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - TreKeyCloakSettings__Authority=${TreKeyCloakAuthority}
       - TreKeyCloakSettings__MetadataAddress=${TreKeyCloakMetadataAddress}
       - TreKeyCloakSettings__BaseUrl=${TreKeyCloakBaseRealmAddress}
@@ -83,8 +83,8 @@ services:
       submissionAPI:
         condition: service_started
     environment:
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - Features__DemoAllInOne=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - DemoModeDefaultP=password123
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Tre;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
@@ -131,7 +131,6 @@ services:
       - SubmissionKeyCloakSettings__UseRedirectURL=${SubmissionAPIKeyCloakUseRedirect}
       - SubmissionKeyCloakSettings__RedirectURL=${SubmissionAPIKeyCloakClientUIRedirectURL}
       - AgentSettings__UseTESK=${UseTESK}
-      - AgentSettings__UseHutch=${UseHutch}
       - AgentSettings__UseRabbit=${UseRabbit}
       - JobSettings__scanSchedule=${scanSchedule}
       - JobSettings__syncSchedule=${syncSchedule}
@@ -178,8 +177,8 @@ services:
     depends_on:
       - DataEgressAPI
     environment:
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - DemoMode=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - Serilog__SeqServerUrl=http://seq:5341
       - DataEgressKeyCloakSettings__Authority=${EgressKeyCloakAuthority}
       - DataEgressKeyCloakSettings__MetadataAddress=${EgressKeyCloakMetadataAddress}
@@ -214,8 +213,8 @@ services:
       keycloak: 
         condition: service_healthy     
     environment:
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - DemoMode=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - DemoModeDefaultP=password123
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DATA-Egress;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq-tre
@@ -272,8 +271,8 @@ services:
     volumes:
       - data-protection:/root/.aspnet/DataProtection-Keys
     environment:
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - DemoMode=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - CONNECTIONSTRINGS__DEFAULTCONNECTION="Server=postgres;Port=32769;Database=DARE-Control;UserId=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;"
       - Serilog__SeqServerUrl=http://seq:5341
       - KeyCloakSettings__Proxy=false
@@ -323,8 +322,8 @@ services:
       minioAAA:
         condition: service_healthy
     environment:
-      - DemoMode=true
-      - KeyCloakDemoMode=true
+      - DemoMode=${DemoMode}
+      - KeyCloakDemoMode=${KeyCloakDemoMode}
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Control;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341

--- a/AllInOne/docker-compose.yml
+++ b/AllInOne/docker-compose.yml
@@ -135,13 +135,13 @@ services:
       - JobSettings__scanSchedule=${scanSchedule}
       - JobSettings__syncSchedule=${syncSchedule}
       - DataEgressAPISettings__Address=http://DataEgressAPI:80
-     # - AgentSettings__TESKAPIURL=http://tesk.test-tesk.dk.serp.ac.uk/ga4gh/tes/v1/tasks
+      #- AgentSettings__TESKAPIURL=${TesAPIUrl}
+      #- AgentSettings__TESKOutputBucketPrefix=${TesOutputBucketPrefix}
       #- AgentSettings__URLHasuraToAdd=${HasuraIP}
       - TreName=${TreName}
       #- AgentSettings__Proxy=true
       #- AgentSettings__ProxyAddresURL=${proxyurl}
       #- AgentSettings__ImageNameToAddToToken=harbor.ukserp.ac.uk/dare-trefx/control-tre-hasura
-      #- AgentSettings__TESKOutputBucketPrefix=http://s3.foo.bar.baz/
       - MinioTRESettings__Url=http://minio2:9000
       - MinioTRESettings__HutchURLOverride=${HutchMinioURLOverride}
       - MinioTRESettings__AccessKey=${TreMinioAdminUser}


### PR DESCRIPTION
- Updates All In One docker-compose to run the 2.9.0 release of the stack.
- Removes old UseHutch env var 
- Sets DemoMode as a FeatureFlag to match latest appsettings for tre-api
- Sets MinIO default URL to be the submission minio url so the login works from the submission page
- Sets TES vars from .env 