### PR TITLE
fix: fix ports in submission layer compose for .NET 7 → .NET 8 upgrade from 80 to 8080 (new default) 

### DIFF
--- a/Submission/.env
+++ b/Submission/.env
@@ -1,4 +1,4 @@
-dareVer=2.15.1
+dareVer=3.0.0
 
 
 PGLOGIN=admin

--- a/Submission/docker-compose.yml
+++ b/Submission/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     networks:
       - sub-net
     ports:
-      - 7220:80
-      - 8888:80
+      - 7220:8080
+      - 8888:8080
     depends_on:
       - submissionAPI
     volumes:
@@ -21,8 +21,8 @@ services:
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - Serilog__SeqServerUrl=http://seq:5341
       - KeyCloakSettings__Proxy=false
-      - DareAPISettings__Address=http://submissionAPI:80
-      - DareAPISettings_HelpAddress=http://submissionAPI:80
+      - DareAPISettings__Address=http://submissionAPI:8080
+      - DareAPISettings_HelpAddress=http://submissionAPI:8080
       - FormIOSettings__UseInternal=true
       - SubmissionKeyCloakSettings__Proxy=${useproxy}
       - SubmissionKeyCloakSettings__ProxyAddresURL=${proxyurl}
@@ -48,7 +48,7 @@ services:
     networks:
       - sub-net
     ports:
-      - 5034:80
+      - 5034:8080
     volumes:
       - data-protection:/root/.aspnet/DataProtection-Keys
     depends_on:
@@ -93,7 +93,7 @@ services:
       - SubmissionKeyCloakSettings__ValidIssuer=${SubmissionValidIssuer}
       - SubmissionKeyCloakSettings__ValidAudience=${SubmissionValidAudience}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -181,7 +181,7 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "nc", "-z", "adminer", "9000"]
+      test: ["CMD", "nc", "-z", "adminer", "8080"]
       timeout: 45s
       interval: 10s
       retries: 10


### PR DESCRIPTION
With a the upgrade to .NET8 a new default port has been introduced (80 to 8080) for ASP .NET web apps. This has broken the deployment compose files. This PR fixes this by updating the relevant port mappings in the submission compose file. 

https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/aspnet-port

## Changes 
- Updated `dareVer` from 2.15.1 to 3.0.0 
- Updated internal docker ports mappings in submissionAPI and submissionUI and any effected env vars from 80 to 8080. 