### PR TITLE
Add volume and DmnPath to Tre-Camunda service

### DIFF
--- a/AllInOne/docker-compose.yml
+++ b/AllInOne/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - VaultSettings__SecretEngine=secret
       - VaultSettings__EnableRetry=true
       - VaultSettings__MaxRetryAttempts=3
-      - DmnPath__Path=app/ProcessModels
+      - DmnPath__Path=/app/ProcessModels
       - TreAPISettings__Address=http://localhost:8072
       # Zeebe settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
@@ -369,7 +369,7 @@ services:
       - Logging__LogLevel__Microsoft.AspNetCore=Warning
       - AllowedHosts=*
       - Serilog__SeqServerUrl=http://seq:5341
-      - DmnPath__Path=app/ProcessModels
+      - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
       - ZeebeBootstrap__Worker__MaxJobsActive=5

--- a/TRE/docker-compose.yml
+++ b/TRE/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       - VaultSettings__SecretEngine=secret
       - VaultSettings__EnableRetry=true
       - VaultSettings__MaxRetryAttempts=3
-      - DmnPath__Path=app/ProcessModels
+      - DmnPath__Path=/app/ProcessModels
       - TreAPISettings__Address=${TreApiPublicUrl}
       # Zeebe settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
@@ -260,7 +260,7 @@ services:
       - Logging__LogLevel__Microsoft.AspNetCore=Warning
       - AllowedHosts=*
       - Serilog__SeqServerUrl=http://seq:5341
-      - DmnPath__Path=app/ProcessModels
+      - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
       - ZeebeBootstrap__Worker__MaxJobsActive=5


### PR DESCRIPTION
Added to All In One and TRE docker-compose.yml:
- add volume to mount the ProcessModel files in TRE-Camunda service
- `DmnPath__Path` to both `tre-api` and `TRE-Camunda` services
- remove unused `TreUISettings__Address`

This should fix the issue of the DMN rules deploying an older version of the file when the docker container restarts or a new image is pulled.