### PR TITLE
fix: add seri log level env var

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.8
+DEPLOYMENT_VERSION=1.7.9
 
 # -----  Env vars to be changed to escape simulation in DemoStack  ------
 

--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.6
+DEPLOYMENT_VERSION=1.7.8
 
 # -----  Env vars to be changed to escape simulation in DemoStack  ------
 
@@ -9,6 +9,10 @@ UseTESK=false
 
 PGLOGIN=admin
 PGPASSWORD=admin
+
+# ----- Serilog Minimum Level ------
+
+SerilogLevel=Information
 
 # ----- CAMUNDA env var ------
 

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -5,7 +5,7 @@ PGLOGIN=admin
 PGPASSWORD=admin
 
 # Serilog Minimum Level
-SerilogLevel=Information
+SerilogLevel=Warning
 
 # Keycloak Host name (if using a local Keycloak instance)
 KeycloakHostName=localhost

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.8
+DEPLOYMENT_VERSION=1.7.9
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -1,8 +1,11 @@
-DEPLOYMENT_VERSION=1.7.6
+DEPLOYMENT_VERSION=1.7.8
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin
 PGPASSWORD=admin
+
+# Serilog Minimum Level
+SerilogLevel=Information
 
 # Keycloak Host name (if using a local Keycloak instance)
 KeycloakHostName=localhost

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -1,8 +1,11 @@
-DEPLOYMENT_VERSION=1.7.6
+DEPLOYMENT_VERSION=1.7.8
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin
 PGPASSWORD=admin
+
+# Serilog Minimum Level
+SerilogLevel=Information
 
 # Encryption settings (Base-64 String, generate by running: openssl rand -base64 32)
 EncryptionSettingsKey=

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -5,7 +5,7 @@ PGLOGIN=admin
 PGPASSWORD=admin
 
 # Serilog Minimum Level
-SerilogLevel=Information
+SerilogLevel=Warning
 
 # Encryption settings (Base-64 String, generate by running: openssl rand -base64 32)
 EncryptionSettingsKey=

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.8
+DEPLOYMENT_VERSION=1.7.9
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin

--- a/ServiceStack/compose-manifests/applications/submission-layer.yml
+++ b/ServiceStack/compose-manifests/applications/submission-layer.yml
@@ -19,6 +19,7 @@ services:
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - Serilog__SeqServerUrl=http://seq:5341
       - Serilog__MinimumLevel__Default=${SerilogLevel}
+      - Logging__LogLevel__Default=${SerilogLevel}
       - KeyCloakSettings__Proxy=false
       - DareAPISettings__Address=http://submissionAPI:8080
       - DareAPISettings_HelpAddress=http://submissionAPI:8080
@@ -75,6 +76,7 @@ services:
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
       - Serilog__MinimumLevel__Default=${SerilogLevel}
+      - Logging__LogLevel__Default=${SerilogLevel}
       - SuppressAntiforgery=${SuppressAntiforgery}
       # Minio settings
       - MinioSettings__Url=http://minioSubmission:9000

--- a/ServiceStack/compose-manifests/applications/submission-layer.yml
+++ b/ServiceStack/compose-manifests/applications/submission-layer.yml
@@ -18,7 +18,7 @@ services:
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - Serilog__SeqServerUrl=http://seq:5341
-      - Serilog__MinimumLevel__Default=Information
+      - Serilog__MinimumLevel__Default=${SerilogLevel}
       - KeyCloakSettings__Proxy=false
       - DareAPISettings__Address=http://submissionAPI:8080
       - DareAPISettings_HelpAddress=http://submissionAPI:8080
@@ -74,7 +74,7 @@ services:
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Control;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
-      - Serilog__MinimumLevel__Default=Information
+      - Serilog__MinimumLevel__Default=${SerilogLevel}
       - SuppressAntiforgery=${SuppressAntiforgery}
       # Minio settings
       - MinioSettings__Url=http://minioSubmission:9000

--- a/ServiceStack/compose-manifests/applications/submission-layer.yml
+++ b/ServiceStack/compose-manifests/applications/submission-layer.yml
@@ -18,6 +18,7 @@ services:
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - Serilog__SeqServerUrl=http://seq:5341
+      - Serilog__MinimumLevel__Default=Information
       - KeyCloakSettings__Proxy=false
       - DareAPISettings__Address=http://submissionAPI:8080
       - DareAPISettings_HelpAddress=http://submissionAPI:8080
@@ -73,6 +74,7 @@ services:
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Control;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
+      - Serilog__MinimumLevel__Default=Information
       - SuppressAntiforgery=${SuppressAntiforgery}
       # Minio settings
       - MinioSettings__Url=http://minioSubmission:9000

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -17,6 +17,7 @@ services:
       - TreAPISettings__PublicApiBaseUrl=${TreApiPublicUrl}
       - Serilog__SeqServerUrl=http://seq:5341
       - Serilog__MinimumLevel__Default=${SerilogLevel}
+      - Logging__LogLevel__Default=${SerilogLevel}
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - sslcookies=${sslcookies}
@@ -93,6 +94,7 @@ services:
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
       - Serilog__MinimumLevel__Default=${SerilogLevel}
+      - Logging__LogLevel__Default=${SerilogLevel}
       - DareAPISettings__Address=${SubmissionAPIAddressURL}
       - DataEgressAPISettings__Address=http://DataEgressAPI:8080
       - EnableExternalHangfire=${EnableExternalHangfire}
@@ -202,6 +204,7 @@ services:
       - AllowedHosts=*
       - Serilog__SeqServerUrl=http://seq:5341
       - Serilog__MinimumLevel__Default=${SerilogLevel}
+      - Logging__LogLevel__Default=${SerilogLevel}
       - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -16,6 +16,7 @@ services:
       - TreAPISettings__InternalApiBaseUrl=http://treAPI:8080
       - TreAPISettings__PublicApiBaseUrl=${TreApiPublicUrl}
       - Serilog__SeqServerUrl=http://seq:5341
+      - Serilog__MinimumLevel__Default=Information
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - sslcookies=${sslcookies}
@@ -91,6 +92,7 @@ services:
       - ConnectionStrings__CredentialsConnection=Server=postgres;Port=5432;Database=TRE_Credentials;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
+      - Serilog__MinimumLevel__Default=Information
       - DareAPISettings__Address=${SubmissionAPIAddressURL}
       - DataEgressAPISettings__Address=http://DataEgressAPI:8080
       - EnableExternalHangfire=${EnableExternalHangfire}
@@ -199,6 +201,7 @@ services:
       - Logging__LogLevel__Microsoft.AspNetCore=Warning
       - AllowedHosts=*
       - Serilog__SeqServerUrl=http://seq:5341
+      - Serilog__MinimumLevel__Default=Information
       - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -16,7 +16,7 @@ services:
       - TreAPISettings__InternalApiBaseUrl=http://treAPI:8080
       - TreAPISettings__PublicApiBaseUrl=${TreApiPublicUrl}
       - Serilog__SeqServerUrl=http://seq:5341
-      - Serilog__MinimumLevel__Default=Information
+      - Serilog__MinimumLevel__Default=${SerilogLevel}
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
       - sslcookies=${sslcookies}
@@ -92,7 +92,7 @@ services:
       - ConnectionStrings__CredentialsConnection=Server=postgres;Port=5432;Database=TRE_Credentials;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq
       - Serilog__SeqServerUrl=http://seq:5341
-      - Serilog__MinimumLevel__Default=Information
+      - Serilog__MinimumLevel__Default=${SerilogLevel}
       - DareAPISettings__Address=${SubmissionAPIAddressURL}
       - DataEgressAPISettings__Address=http://DataEgressAPI:8080
       - EnableExternalHangfire=${EnableExternalHangfire}
@@ -201,7 +201,7 @@ services:
       - Logging__LogLevel__Microsoft.AspNetCore=Warning
       - AllowedHosts=*
       - Serilog__SeqServerUrl=http://seq:5341
-      - Serilog__MinimumLevel__Default=Information
+      - Serilog__MinimumLevel__Default=${SerilogLevel}
       - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
       - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500


### PR DESCRIPTION
This PR supports the PR https://github.com/SwanseaUniversityMedical/5s-Tes/pull/74 by adding the env var for Serilog's log level to the deployment files.