### PR TITLE
Update and pin down versions

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.9
+DEPLOYMENT_VERSION=1.7.11
 
 # -----  Env vars to be changed to escape simulation in DemoStack  ------
 

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.9
+DEPLOYMENT_VERSION=1.7.11
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -1,4 +1,4 @@
-DEPLOYMENT_VERSION=1.7.9
+DEPLOYMENT_VERSION=1.7.11
 
 # Internal Postgres Superuser creds
 PGLOGIN=admin

--- a/ServiceStack/compose-manifests/shared/credentials.yml
+++ b/ServiceStack/compose-manifests/shared/credentials.yml
@@ -1,5 +1,4 @@
 services:
-
   # ------ Camunda Orchestration ------
   # -----------------------------------------
 
@@ -36,7 +35,7 @@ services:
 
   # ------ Camunda Connectors ------
   # -----------------------------------------
-  
+
   connectors:
     image: camunda/connectors-bundle:8.8.1
     container_name: connectors
@@ -141,10 +140,10 @@ services:
     depends_on:
       - openldap
 
- # ----- Vault Secret Management ------
- # ---------------------------------------------
+  # ----- Vault Secret Management ------
+  # ---------------------------------------------
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.21.4
     container_name: vault
     mem_limit: 512M
     mem_reservation: 256M

--- a/ServiceStack/compose-manifests/shared/omop-lite.yml
+++ b/ServiceStack/compose-manifests/shared/omop-lite.yml
@@ -2,7 +2,7 @@ services:
   # ------ OMOP Lite ------
   # ---------------------------------------------
   omop-lite:
-    image: ghcr.io/health-informatics-uon/omop-lite
+    image: ghcr.io/health-informatics-uon/omop-lite:0.5.0
     container_name: omop-lite
     depends_on:
       - postgresql


### PR DESCRIPTION
This PR updates the 5S-TES version to the latest one. 

Also, pin the version of OMOP LITE (due to the issue https://github.com/Health-Informatics-UoN/omop-lite/issues/80) and Vault (due to the recent major update - https://github.com/hashicorp/vault/releases, which caused some issues when I set up the VM for TRE TESK).