### PR TITLE
Move the creds away from the compose files

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -8,6 +8,9 @@ AppName=Five Safes TES
 DemoMode=true
 UseTESK=false
 
+# Demo Mode Password
+DemoModePassword=password123
+
 # ----- Postgres env var ------
 
 PGLOGIN=admin
@@ -25,6 +28,16 @@ ELASTIC_VERSION=8.17.5
 
 CredentialAPISettingsStartWebhookUrl=http://connectors:8080/inbound/StartCredentials
 CredentialAPISettingsRevokeWebhookUrl=http://connectors:8080/inbound/RevokeCredentials
+
+CamundaUsername=demo
+CamundaPassword=demo
+
+# LDAP Credentials
+LDAPAdminPassword=admin
+LDAPConfigPassword=config
+
+# Vault Credentials
+VaultRootToken=dev-only-token
 
 # ------ TRE DB Credentials ------
 

--- a/DemoStack/docker-compose.yml
+++ b/DemoStack/docker-compose.yml
@@ -93,12 +93,12 @@ configs:
             enabled: false
           initialization:
             users:
-              - username: "demo"
-                password: "demo"
-                name: "Demo User"
-                email: "demo@demo.com"
+              - username: ${CamundaUsername}
+                password: ${CamundaPassword}
+                name: "Camunda User"
+                email: "camunda@camunda.com"
             defaultRoles.admin.users:
-              - "demo"
+              - ${CamundaUsername}
         database.index.numberOfReplicas: 0 # Single node elasticsearch so we disable replication
         data:
           secondary-storage:

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -10,6 +10,9 @@ PGPASSWORD=admin
 # Serilog Minimum Level
 SerilogLevel=Warning
 
+# Vault Credentials
+VaultRootToken=dev-only-token
+
 # Keycloak Host name (if using a local Keycloak instance)
 KeycloakHostName=localhost
 

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -8,6 +8,17 @@ AppName=Five Safes TES
 PGLOGIN=admin
 PGPASSWORD=admin
 
+# LDAP Credentials (to be changed in production)
+LDAPAdminPassword=admin
+LDAPConfigPassword=config
+
+# Camunda Credentials (to be changed in production)
+CamundaUsername=demo
+CamundaPassword=demo
+
+# Vault Credentials (to be changed in production)
+VaultRootToken=dev-only-token
+
 # Serilog Minimum Level
 SerilogLevel=Warning
 
@@ -95,6 +106,8 @@ CONFIG_PATH=../../../DeploymentStack/TRE/config
 # Note: Env vars below are unlikely to be changed 
 # Always keep this as false in real deployments:
 DemoMode=false
+# Demo Mode Password (unused, but here to prevent warnings)
+DemoModePassword=password
 # Always keep this as true in real deployments
 UseTESK=true
 # Allows Keycloak to not require https:

--- a/DeploymentStack/TRE/docker-compose.yml
+++ b/DeploymentStack/TRE/docker-compose.yml
@@ -10,11 +10,11 @@ include:
   # ----- Shared Services -----
   # - Platform Service: (PostgreSQL, Adminer, Serilog, RabbitMQ)
   - ../../ServiceStack/compose-manifests/shared/platform.yml
-    # - Credential Service: (Camunda, Connectors, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
+  # - Credential Service: (Camunda, Connectors, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
   - ../../ServiceStack/compose-manifests/shared/credentials.yml
   # - Auth Service: (Keycloak - Optional)
   - ../../ServiceStack/compose-manifests/shared/auth.yml
-    # - OMOP Lite Service: (OMOP Lite - Optional - Uncomment to enable)
+  # - OMOP Lite Service: (OMOP Lite - Optional - Uncomment to enable)
   #  - ../../ServiceStack/compose-manifests/shared/omop-lite.yml
 
   # ----- Storage Services -----
@@ -85,12 +85,12 @@ configs:
             enabled: false
           initialization:
             users:
-              - username: "demo"
-                password: "demo"
-                name: "Demo User"
-                email: "demo@demo.com"
+              - username: ${CamundaUsername}
+                password: ${CamundaPassword}
+                name: "Camunda User"
+                email: "camunda@camunda.com"
             defaultRoles.admin.users:
-              - "demo"
+              - ${CamundaUsername}
         database.index.numberOfReplicas: 0 # Single node elasticsearch so we disable replication
         data:
           secondary-storage:

--- a/ServiceStack/compose-manifests/applications/egress-layer.yml
+++ b/ServiceStack/compose-manifests/applications/egress-layer.yml
@@ -53,7 +53,7 @@ services:
     environment:
       - DemoMode=${DemoMode}
       - KeyCloakDemoMode=${KeyCloakDemoMode}
-      - DemoModeDefaultP=password123
+      - DemoModeDefaultP=${DemoModePassword}
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DATA-Egress;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq-tre
       - Serilog__SeqServerUrl=http://seq:5341

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -89,7 +89,7 @@ services:
       - Features__DemoAllInOne=${DemoMode}
       - Features__EphemeralCredentials=true
       - KeyCloakDemoMode=${KeyCloakDemoMode}
-      - DemoModeDefaultP=password123
+      - DemoModeDefaultP=${DemoModePassword}
       - ConnectionStrings__DefaultConnection=Server=postgres;Port=5432;Database=DARE-Tre;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - ConnectionStrings__CredentialsConnection=Server=postgres;Port=5432;Database=TRE_Credentials;Include Error Detail=true;User Id=${PGLOGIN};Password=${PGPASSWORD};TrustServerCertificate=True;
       - RabbitMQ__HostAddress=rabbitmq

--- a/ServiceStack/compose-manifests/shared/credentials.yml
+++ b/ServiceStack/compose-manifests/shared/credentials.yml
@@ -75,8 +75,8 @@ services:
       LDAP_LOG_LEVEL: "256"
       LDAP_ORGANISATION: "TRE Ephemeral Credentials"
       LDAP_DOMAIN: "camundaephemeral.local"
-      LDAP_ADMIN_PASSWORD: "admin"
-      LDAP_CONFIG_PASSWORD: "config"
+      LDAP_ADMIN_PASSWORD: ${LDAPAdminPassword}
+      LDAP_CONFIG_PASSWORD: ${LDAPConfigPassword}
       LDAP_TLS: "false"
       LDAP_ADD_LDIF_URL: "file:///container/service/slapd/assets/init.ldif"
     volumes:
@@ -96,7 +96,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "ldapsearch -x -H ldap://localhost -b dc=camundaephemeral,dc=local -D 'cn=admin,dc=camundaephemeral,dc=local' -w admin",
+          "ldapsearch -x -H ldap://localhost -b dc=camundaephemeral,dc=local -D 'cn=admin,dc=camundaephemeral,dc=local' -w ${LDAPAdminPassword}",
         ]
       interval: 10s
       timeout: 5s
@@ -152,7 +152,7 @@ services:
     ports:
       - "8200:8200"
     environment:
-      - VAULT_DEV_ROOT_TOKEN_ID=dev-only-token
+      - VAULT_DEV_ROOT_TOKEN_ID=${VaultRootToken}
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - VAULT_ADDR=http://127.0.0.1:8200
     volumes:
@@ -169,7 +169,7 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-    command: ["vault", "server", "-dev", "-dev-root-token-id=dev-only-token"]
+    command: ["vault", "server", "-dev", "-dev-root-token-id=${VaultRootToken}"]
 
   # ------ Elasticsearch ------
   # -----------------------------------


### PR DESCRIPTION
This PR moved the default creds of Vault, LDAP and Camunda away from the config inside the compose files, making it easier to manage these configs in .env files.