### PR TITLE
Fix vault and KC pass

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -35,6 +35,9 @@ LDAPConfigPassword=config
 # Vault Credentials
 VaultRootToken=dev-only-token
 
+# Keycloak Credentials
+KeycloakBootstrapAdminPassword=admin
+
 # TRE Data DB Credentials
 # Used for the TRE Agent to create temporary credentials against any Postgres database:
 TRE_DATA_SERVER=postgres

--- a/DeploymentStack/Submission/.env.example
+++ b/DeploymentStack/Submission/.env.example
@@ -13,6 +13,9 @@ SerilogLevel=Warning
 # Vault Credentials
 VaultRootToken=dev-only-token
 
+# Keycloak Credentials
+KeycloakBootstrapAdminPassword=admin
+
 # Keycloak Host name (if using a local Keycloak instance)
 KeycloakHostName=localhost
 

--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -19,6 +19,9 @@ CamundaPassword=demo
 # Vault Credentials (to be changed in production)
 VaultRootToken=dev-only-token
 
+# Keycloak Credentials (to be changed in production)
+KeycloakBootstrapAdminPassword=admin
+
 # Serilog Minimum Level
 SerilogLevel=Warning
 

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -166,7 +166,7 @@ services:
       - TreAPISettings__Address=${TreApiPublicUrl}
       # Vault settings
       - VaultSettings__BaseUrl=http://vault:8200
-      - VaultSettings__Token=dev-only-token
+      - VaultSettings__Token=${VaultRootToken}
       - VaultSettings__TimeoutSeconds=30
       - VaultSettings__SecretEngine=secret
       - VaultSettings__EnableRetry=true
@@ -226,7 +226,7 @@ services:
       - LdapSettings__UseSSL=false
       # Vault settings
       - VaultSettings__BaseUrl=http://vault:8200
-      - VaultSettings__Token=dev-only-token
+      - VaultSettings__Token=${VaultRootToken}
       - VaultSettings__TimeoutSeconds=30
       - VaultSettings__SecretEngine=secret
       - VaultSettings__EnableRetry=true

--- a/ServiceStack/compose-manifests/shared/auth.yml
+++ b/ServiceStack/compose-manifests/shared/auth.yml
@@ -1,5 +1,4 @@
 services:
-
   # ------ Keycloak Identity Provider ------
   # ---------------------------------------------
 
@@ -22,7 +21,7 @@ services:
       KEYCLOAK_METRICS_ENABLED: true
       # Admin credentials
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KeycloakBootstrapAdminPassword}
     networks:
       - sub-net
     command: start-dev  --import-realm #--verbose


### PR DESCRIPTION
This PR fix the value of the Vault token passed to Camunda and moves the password of KC out to .env.