### PR TITLE
Add Health Log Deletion Setting

### DIFF
--- a/DeploymentStack/TRE/.env.example
+++ b/DeploymentStack/TRE/.env.example
@@ -89,6 +89,8 @@ syncSchedule=10
 scanSchedule=1
 # The frequency at which the health check runs - default every 1 minute
 healthCheckSchedule=1
+# The length of time a health check log is kept in the database before it gets deleted - default 30 days
+daysBeforeHealthLogDeletion=30
 
 # Egress Keycloak Settings:
 EgressKeyCloakClientUIRedirectURL=http://localhost:8100

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -109,6 +109,7 @@ services:
       - JobSettings__scanSchedule=${scanSchedule}
       - JobSettings__syncSchedule=${syncSchedule}
       - JobSettings__healthCheckSchedule=${healthCheckSchedule}
+      - JobSettings__DaysBeforeHealthLogDeletion=${daysBeforeHealthLogDeletion}
       - AgentSettings__TESKAPIURL=${TesAPIUrl}
       - AgentSettings__TESKOutputBucketPrefix=${TesOutputBucketPrefix}
       - TreName=${TreName}


### PR DESCRIPTION
Add a setting to determine the amount of time a health check log stays in the database for before it gets deleted.