### PR TITLE
fix: remove Camunda connectors-bundle service camunda connectors

### DIFF
--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -28,6 +28,9 @@ EncryptionSettingsKey=9pDUei4zHnuXrC0Hb0KSG0g1U4GsV6ajZf+/kYKtrI8=
 CamundaUsername=demo
 CamundaPassword=demo
 
+# Elastic Version (must match Elasticsearch image version in credentials.yml)
+ELASTIC_VERSION=8.17.5
+
 # LDAP Credentials
 LDAPAdminPassword=admin
 LDAPConfigPassword=config

--- a/DemoStack/.env
+++ b/DemoStack/.env
@@ -28,9 +28,6 @@ EncryptionSettingsKey=9pDUei4zHnuXrC0Hb0KSG0g1U4GsV6ajZf+/kYKtrI8=
 CamundaUsername=demo
 CamundaPassword=demo
 
-# Elastic Version (must match Elasticsearch image version in credentials.yml)
-ELASTIC_VERSION=8.17.5
-
 # LDAP Credentials
 LDAPAdminPassword=admin
 LDAPConfigPassword=config

--- a/DemoStack/docker-compose.yml
+++ b/DemoStack/docker-compose.yml
@@ -52,8 +52,6 @@ volumes:
     driver: local
   elastic:
     driver: local
-  kibana:
-    driver: local
   vault_data:
     driver: local
   vault_logs:

--- a/DemoStack/docker-compose.yml
+++ b/DemoStack/docker-compose.yml
@@ -52,6 +52,8 @@ volumes:
     driver: local
   elastic:
     driver: local
+  kibana:
+    driver: local
   vault_data:
     driver: local
   vault_logs:
@@ -69,31 +71,3 @@ networks:
   sub-net:
     driver: bridge
 
-configs:
-  orchestration-config:
-    content: |
-      camunda:
-        system:
-          cpu-thread-count: "3"
-          io-thread-count: "3"
-        security:
-          authentication:
-            method: "basic"
-            unprotectedApi: true  # This is needed for internal Camunda - TRE-Camunda communication
-          authorizations:
-            enabled: false  # This is needed for internal Camunda - TRE-Camunda communication
-          initialization:
-            users:
-              - username: ${CamundaUsername}
-                password: ${CamundaPassword}
-                name: "Camunda User"
-                email: "camunda@camunda.com"
-            defaultRoles.admin.users:
-              - ${CamundaUsername}
-        database.index.numberOfReplicas: 0 # Single node elasticsearch so we disable replication
-        data:
-          secondary-storage:
-            type: elasticsearch
-            elasticsearch:
-              cluster-name: elasticsearch
-              url: "http://elasticsearch:9200"

--- a/DemoStack/docker-compose.yml
+++ b/DemoStack/docker-compose.yml
@@ -13,7 +13,7 @@ include:
   # ----- Shared Services -----
   # - Platform Service: (PostgreSQL, Adminer, Serilog, RabbitMQ)
   # - Auth Service: (Keycloak)
-  # - Credentials Service: (Camunda, Connectors, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
+  # - Credentials Service: (Camunda, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
 
   - ../ServiceStack/compose-manifests/shared/platform.yml
   - ../ServiceStack/compose-manifests/shared/auth.yml
@@ -70,14 +70,6 @@ networks:
     driver: bridge
 
 configs:
-  connectors-config:
-    content: |
-      camunda:
-        client:
-          mode: self-managed
-          grpc-address: http://orchestration:26500
-          rest-address: http://orchestration:8080
-
   orchestration-config:
     content: |
       camunda:

--- a/DeploymentStack/TRE/docker-compose.yml
+++ b/DeploymentStack/TRE/docker-compose.yml
@@ -44,8 +44,6 @@ volumes:
     driver: local
   elastic:
     driver: local
-  kibana:
-    driver: local
   vault_data:
     driver: local
   vault_logs:

--- a/DeploymentStack/TRE/docker-compose.yml
+++ b/DeploymentStack/TRE/docker-compose.yml
@@ -44,6 +44,8 @@ volumes:
     driver: local
   elastic:
     driver: local
+  kibana:
+    driver: local
   vault_data:
     driver: local
   vault_logs:
@@ -61,32 +63,3 @@ networks:
   sub-net:
     driver: bridge
 
-configs:
-  orchestration-config:
-    content: |
-      management.endpoints.configprops.show-values: always
-      camunda:
-        system:
-          cpu-thread-count: "3"
-          io-thread-count: "3"
-        security:
-          authentication:
-            method: "basic"
-            unprotectedApi: true
-          authorizations:
-            enabled: false
-          initialization:
-            users:
-              - username: ${CamundaUsername}
-                password: ${CamundaPassword}
-                name: "Camunda User"
-                email: "camunda@camunda.com"
-            defaultRoles.admin.users:
-              - ${CamundaUsername}
-        database.index.numberOfReplicas: 0 # Single node elasticsearch so we disable replication
-        data:
-          secondary-storage:
-            type: elasticsearch
-            elasticsearch:
-              cluster-name: elasticsearch
-              url: "http://elasticsearch:9200"

--- a/DeploymentStack/TRE/docker-compose.yml
+++ b/DeploymentStack/TRE/docker-compose.yml
@@ -10,7 +10,7 @@ include:
   # ----- Shared Services -----
   # - Platform Service: (PostgreSQL, Adminer, Serilog, RabbitMQ)
   - ../../ServiceStack/compose-manifests/shared/platform.yml
-  # - Credential Service: (Camunda, Connectors, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
+  # - Credential Service: (Camunda, Vault, OpenLDAP, LDAP Init, phpLDAPadmin, Elastic Search)
   - ../../ServiceStack/compose-manifests/shared/credentials.yml
   # - Auth Service: (Keycloak - Optional)
   - ../../ServiceStack/compose-manifests/shared/auth.yml
@@ -62,14 +62,6 @@ networks:
     driver: bridge
 
 configs:
-  connectors-config:
-    content: |
-      camunda:
-        client:
-          mode: self-managed
-          grpc-address: http://orchestration:26500
-          rest-address: http://orchestration:8080
-
   orchestration-config:
     content: |
       management.endpoints.configprops.show-values: always

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -165,8 +165,7 @@ services:
       - MinioSubSettings__SecretKey=${SubmissionS3RootPass}
       - MinioSubSettings__AdminConsole=${SubmissionS3ConsoleUrl}
       # Credentials and DMN settings
-      - CredentialAPISettings__StartWebhookUrl=http://connectors:8080/inbound/StartCredentials
-      - CredentialAPISettings__RevokeWebhookUrl=http://connectors:8080/inbound/RevokeCredentials
+
       - DmnPath__Path=/app/ProcessModels
       - TreAPISettings__Address=${TreApiPublicUrl}
       # Vault settings

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -68,7 +68,7 @@ services:
   # ------ TRE Agent - API -------
   # -----------------------------------
   tre-api:
-    image: harbor.federated-analytics.ac.uk/5s-tes/agent-api:pr-129-ea56fb7
+    image: harbor.federated-analytics.ac.uk/5s-tes/agent-api:${DEPLOYMENT_VERSION}
     container_name: treapi
     restart: always
     networks:
@@ -198,7 +198,7 @@ services:
   # --------------------------------------------
 
   TRE-Camunda:
-    image: harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda:pr-129-ea56fb7
+    image: harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda:${DEPLOYMENT_VERSION}
     container_name: TRE-Camunda
     restart: always
     networks:

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -87,7 +87,7 @@ services:
         condition: service_healthy
       vault:
         condition: service_healthy
-      orchestration:
+      zeebe:
         condition: service_healthy
     environment:
       # General settings
@@ -176,7 +176,7 @@ services:
       - VaultSettings__EnableRetry=true
       - VaultSettings__MaxRetryAttempts=3
       # Zeebe settings
-      - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
+      - ZeebeBootstrap__Client__GatewayAddress=zeebe:26500
       - ZeebeBootstrap__Worker__MaxJobsActive=5
       - ZeebeBootstrap__Worker__TimeoutInMilliseconds=5000
       - ZeebeBootstrap__Worker__PollIntervalInMilliseconds=1000
@@ -198,7 +198,7 @@ services:
     networks:
       - sub-net
     depends_on:
-      orchestration:
+      zeebe:
         condition: service_healthy
       openldap:
         condition: service_healthy
@@ -217,7 +217,7 @@ services:
       - Logging__LogLevel__Default=${SerilogLevel}
       - DmnPath__Path=/app/ProcessModels
       # Zeebe Bootstrap settings
-      - ZeebeBootstrap__Client__GatewayAddress=orchestration:26500
+      - ZeebeBootstrap__Client__GatewayAddress=zeebe:26500
       - ZeebeBootstrap__Worker__MaxJobsActive=5
       - ZeebeBootstrap__Worker__TimeoutInMilliseconds=5000
       - ZeebeBootstrap__Worker__PollIntervalInMilliseconds=1000

--- a/ServiceStack/compose-manifests/applications/tre-layer.yml
+++ b/ServiceStack/compose-manifests/applications/tre-layer.yml
@@ -68,7 +68,7 @@ services:
   # ------ TRE Agent - API -------
   # -----------------------------------
   tre-api:
-    image: harbor.federated-analytics.ac.uk/5s-tes/agent-api:${DEPLOYMENT_VERSION}
+    image: harbor.federated-analytics.ac.uk/5s-tes/agent-api:pr-129-ea56fb7
     container_name: treapi
     restart: always
     networks:
@@ -192,7 +192,7 @@ services:
   # --------------------------------------------
 
   TRE-Camunda:
-    image: harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda:${DEPLOYMENT_VERSION}
+    image: harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda:pr-129-ea56fb7
     container_name: TRE-Camunda
     restart: always
     networks:

--- a/ServiceStack/compose-manifests/shared/credentials.yml
+++ b/ServiceStack/compose-manifests/shared/credentials.yml
@@ -33,37 +33,6 @@ services:
       elasticsearch:
         condition: service_healthy
 
-  # ------ Camunda Connectors ------
-  # -----------------------------------------
-
-  connectors:
-    image: camunda/connectors-bundle:8.8.1
-    container_name: connectors
-    ports:
-      - "127.0.0.1:8086:8080"
-    environment:
-      - management.endpoints.web.exposure.include=health,configprops
-      - management.endpoint.health.probes.enabled=true
-    mem_limit: 1g
-    restart: unless-stopped
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/8080' || exit 1",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    configs:
-      - source: connectors-config
-        target: application.yaml
-    networks:
-      - sub-net
-    depends_on:
-      orchestration:
-        condition: service_healthy
 
   # ------ OpenLDAP Identity Provider ------
   # ---------------------------------------------

--- a/ServiceStack/compose-manifests/shared/credentials.yml
+++ b/ServiceStack/compose-manifests/shared/credentials.yml
@@ -3,7 +3,7 @@ services:
   # -----------------------------------------
 
   zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
-    image: camunda/zeebe:8.2
+    image: camunda/zeebe:8.2.0
     container_name: zeebe
     ports:
       - "127.0.0.1:26500:26500"
@@ -177,47 +177,3 @@ services:
     networks:
       - sub-net
 
-  # ------ Kibana Monitoring Dashboard ------
-  # (Free monitoring alternative - replaces Operate which requires a licence)
-  # -------------------------------------------
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
-    container_name: kibana
-    ports:
-      - "127.0.0.1:5601:5601"
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - SERVER_NAME=kibana
-      - XPACK_SECURITY_ENABLED=false
-      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=a7a6311933d3503b89bc2dbc36572c33a7a6311933d3503b89bc2dbc36572c33
-    mem_limit: 1g
-    restart: unless-stopped
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -sf http://localhost:5601/api/status | grep -q '\"level\":\"available\"'",
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 10
-      start_period: 120s
-    networks:
-      - sub-net
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-
-  kibana-init:
-    image: curlimages/curl:8.6.0
-    container_name: kibana-init
-    volumes:
-      - ${CONFIG_PATH}/kibana-provisioning:/init
-    entrypoint: ["/bin/sh", "/init/setup.sh"]
-    networks:
-      - sub-net
-    depends_on:
-      kibana:
-        condition: service_healthy
-    restart: "no"

--- a/ServiceStack/compose-manifests/shared/credentials.yml
+++ b/ServiceStack/compose-manifests/shared/credentials.yml
@@ -1,16 +1,23 @@
 services:
-  # ------ Camunda Orchestration ------
+  # ------ Zeebe Workflow Engine ------
   # -----------------------------------------
 
-  orchestration: # Consolidated Zeebe + Operate + Tasklist - https://docs.camunda.io/docs/self-managed/setup/deploy/other/docker/#zeebe
-    image: camunda/camunda:8.8.0
-    container_name: orchestration
+  zeebe: # https://docs.camunda.io/docs/self-managed/platform-deployment/docker/#zeebe
+    image: camunda/zeebe:8.2
+    container_name: zeebe
     ports:
       - "127.0.0.1:26500:26500"
       - "127.0.0.1:9600:9600"
       - "127.0.0.1:8088:8080"
     environment:
-      - JAVA_TOOL_OPTIONS="-XX:+PrintFlagsFinal"
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL=http://elasticsearch:9200
+      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE=1
+      - ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK=0.998
+      - ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK=0.999
+      - ZEEBE_BROKER_THREADS_CPUTHREADCOUNT=3
+      - ZEEBE_BROKER_THREADS_IOTHREADCOUNT=3
+      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
     mem_limit: 2g
     restart: always
     healthcheck:
@@ -24,9 +31,6 @@ services:
       start_period: 30s
     volumes:
       - zeebe:/usr/local/zeebe/data
-    configs:
-      - source: orchestration-config
-        target: /usr/local/camunda/config/application.yaml
     networks:
       - sub-net
     depends_on:
@@ -172,3 +176,48 @@ services:
       - elastic:/usr/share/elasticsearch/data
     networks:
       - sub-net
+
+  # ------ Kibana Monitoring Dashboard ------
+  # (Free monitoring alternative - replaces Operate which requires a licence)
+  # -------------------------------------------
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
+    container_name: kibana
+    ports:
+      - "127.0.0.1:5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - SERVER_NAME=kibana
+      - XPACK_SECURITY_ENABLED=false
+      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=a7a6311933d3503b89bc2dbc36572c33a7a6311933d3503b89bc2dbc36572c33
+    mem_limit: 1g
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:5601/api/status | grep -q '\"level\":\"available\"'",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    networks:
+      - sub-net
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
+  kibana-init:
+    image: curlimages/curl:8.6.0
+    container_name: kibana-init
+    volumes:
+      - ${CONFIG_PATH}/kibana-provisioning:/init
+    entrypoint: ["/bin/sh", "/init/setup.sh"]
+    networks:
+      - sub-net
+    depends_on:
+      kibana:
+        condition: service_healthy
+    restart: "no"


### PR DESCRIPTION
**Summary**
As part of investigating whether Camunda can run on a lower version (TREFX-625), the connectors-bundle service has been identified as the primary blocker — it pins us to a specific Camunda version and requires commercial connector dependencies that are not needed.

Process triggers (credential start and revoke) have been refactored in the application layer (5s-Tes — fix/TREFX-625-Check-if-Camunda-can-version-can-be-lower) to use direct Zeebe CreateProcessInstance gRPC calls instead of webhook connector start events. This deployment repo reflects that change.

- Remove connectors service from credentials.yml
- Remove connectors-config from DemoStack and DeploymentStack/TRE compose files
- Remove CredentialAPISettings webhook URL env vars from tre-layer.yml

**Test plan**
 - Start DemoStack and confirm all containers come up healthy without the connectors service
 - - Trigger a credential start/revoke flow and confirm it completes via direct Zeebe call
 Confirm no errors relating to missing connectors service in Seq logs